### PR TITLE
Fixed error preventing these rules from loading

### DIFF
--- a/CVE-2015-1770.lua
+++ b/CVE-2015-1770.lua
@@ -47,7 +47,7 @@ function doc_handler(t,verbose)
     local buffers = {}
     if z then
         for w in z:files() do
-            if string.find(w.filename,"/activeX/activeX%d+\.xml") then
+            if string.find(w.filename,"/activeX/activeX%d+%.xml") then
                 f = z:open(w.filename);
                 u = f:read("*all")
                 --convert to lowercase

--- a/CVE-2015-2375.lua
+++ b/CVE-2015-2375.lua
@@ -46,7 +46,7 @@ function doc_handler(t,verbose)
     local buffers = {}
     if z then
         for w in z:files() do
-            if string.find(w.filename,"xl/tables/table%d+\.xml") then
+            if string.find(w.filename,"xl/tables/table%d+%.xml") then
                 f = z:open(w.filename);
                 u = f:read("*all")
                 --convert to lowercase


### PR DESCRIPTION
Rules were using a \ for the escape sequence instead of % resulting in an error for 'invalid escape sequence'
